### PR TITLE
catch function of arity 4

### DIFF
--- a/src/chokecherry.erl
+++ b/src/chokecherry.erl
@@ -48,8 +48,14 @@ info(Module, StringFormat, Args) ->
     chokecherry_shaper:put({[{module, Module}, {pid, self()}], StringFormat, Args}).
 
 -spec info(atom(), list(), string(), list()) -> 'ok'.
-info(Module, [MetaData], StringFormat, Args) ->
-    chokecherry_shaper:put({[{module, Module}, {pid, self()}, MetaData], StringFormat, Args}).
+info(Module, MetaData, StringFormat, Args) ->
+    Meta = case MetaData of
+        [] -> [{module, Module}, {pid, self()}];
+        [Element|[]] -> [{module, Module}, {pid, self()}, Element];
+        EList when is_list(EList) -> [{module, Module}, {pid, self()}] ++ EList;
+        Else -> [{module, Module}, {pid, self()}, Else]
+    end,
+    chokecherry_shaper:put({Meta, StringFormat, Args}).
 
 
 -spec warning(string()) -> 'ok'.

--- a/src/chokecherry.erl
+++ b/src/chokecherry.erl
@@ -10,6 +10,7 @@
 -export([info/1,
          info/2,
          info/3,
+         info/4, 
          warning/1,
          warning/2,
          warning/3,
@@ -45,6 +46,10 @@ info(StringFormat, Args) ->
 -spec info(atom(), string(), list()) -> 'ok'.
 info(Module, StringFormat, Args) ->
     chokecherry_shaper:put({[{module, Module}, {pid, self()}], StringFormat, Args}).
+
+-spec info(atom(), list(), string(), list()) -> 'ok'.
+info(Module, MetaData, StringFormat, Args) ->
+    chokecherry_shaper:put({[{module, Module}, {pid, self()}, MetaData], StringFormat, Args}).
 
 
 -spec warning(string()) -> 'ok'.

--- a/src/chokecherry.erl
+++ b/src/chokecherry.erl
@@ -48,7 +48,7 @@ info(Module, StringFormat, Args) ->
     chokecherry_shaper:put({[{module, Module}, {pid, self()}], StringFormat, Args}).
 
 -spec info(atom(), list(), string(), list()) -> 'ok'.
-info(Module, MetaData, StringFormat, Args) ->
+info(Module, [MetaData], StringFormat, Args) ->
     chokecherry_shaper:put({[{module, Module}, {pid, self()}, MetaData], StringFormat, Args}).
 
 


### PR DESCRIPTION
Hi, there is also lager function that transformed into arity of 4, example:

`lager:info([{tag, some_Tag}], Str, Args)`

transformed into:

`chokecherry:info(module_name, [{tag,some_Tag}], Str, Args)`
